### PR TITLE
ci 테스트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+# ci, Pull Request에서 테스트 및 커버리지
+
+name: CI Workflow
+
+on:
+  pull_request:
+    branches: [dev, main] # dev, main 브랜치에 pull request 될 때 실행됨
+    paths-ignore: ["README.md", "**/*.md"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # PR 코멘트에 커버리지 요약 남기기
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Grant execute permission for gradlew # github Actions에서 gradlew 권한 주기
+        run: chmod +x gradlew
+
+      - name: Cache Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run tests with coverage (fails if coverage < 80%)
+        run: ./gradlew test jacocoTestReport jacocoTestCoverageVerification --no-daemon
+
+      - name: Upload coverage report (HTML)
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# 멀티 스테이지, 경량 런타임
+
+# build stage
+FROM gradle:8.9-jdk17-alpine AS build
+WORKDIR /app
+COPY . .
+RUN chmod +x ./gradlew && ./gradlew clean bootJar --no-daemon
+
+# run stage
+FROM eclipse-temurin:17-jre-alpine
+ENV SPRING_PROFILES_ACTIVE=prod \
+    JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75"
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar /app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.9'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco' // jacoco 추가
 }
 
 group = 'com.codeit'
@@ -50,4 +51,32 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport, jacocoTestCoverageVerification // jacoco Test 추가
+}
+
+// jacoco 추가
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+// jacocoTestReport 추가
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true // CI에서 파싱하기 위함
+        html.required = true // 보기 편하게 추가
+    }
+}
+
+// jacocoTestCoverageVerification 추가
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80 // 80% 미만이면 실패함
+            }
+        }
+    }
 }

--- a/src/main/java/com/codeit/monew/base/entity/BaseEntity.java
+++ b/src/main/java/com/codeit/monew/base/entity/BaseEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.UuidGenerator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;


### PR DESCRIPTION
## 📌 작업 내용
- build.gradle에 Jacoco 관련 의존성들을 추가했습니다.
- Dockerfile을 작성했습니다.
- .github/workflows 폴더를 생성하고 ci.yml 파일 생성 후 작성했습니다.

## 🔗 관련 이슈
- Closes #이슈번호

## 🐛 에러 상황 및 원인 (선택)
- 이 pull request의 ci.yml에서 Setup JDK 17이 두 갈래로 나뉘어 있는 문제
    - Setup JDK 17 스탭에서 두개의 리스트 항목으로 쪼개져 있음(- name, -uses), 다음 PR에서 해결예정

## 🙋 리뷰 요청사항
- build.gradle 의존성 여부
- ci.yml 에서 on/paths-ignore이 잘 작성되어있는지
- jobs의 과정이 잘 되어있는지