### PR TITLE
ci(CI/CD 파이프라인): 테스트 커버리지 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,32 @@ jobs:
           name: jacoco-report
           path: build/reports/jacoco/test/html
 
-# PR 코멘트
+# 커버리지 수치를 jacoco XML에서 뽑은 다음 PR 코멘트로 남기기
+      - name: Install xmllint (parsing XML) # xmllint 설치하기
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
+# 커버리지 코멘트 설계
+      - name: Extract coverage numbers
+        id: coverage
+        run: |
+          XML="build/reports/jacoco/test/jacocoTestReport.xml"
+          COVERED=$(xmllint --xpath "string(//counter[@type='LINE']/@covered)" "$XML" 2>/dev/null || echo 0)
+          MISSED=$(xmllint --xpath "string(//counter[@type='LINE']/@missed)" "$XML" 2>/dev/null || echo 0)
+          TOTAL=$((COVERED + MISSED))
+          PCT=$(awk "BEGIN { if ($TOTAL==0) print 0; else printf \"%.2f\", ($COVERED/$TOTAL)*100 }")
+          echo "covered=$COVERED" >> $GITHUB_OUTPUT
+          echo "missed=$MISSED" >> $GITHUB_OUTPUT
+          echo "total=$TOTAL" >> $GITHUB_OUTPUT
+          echo "pct=$PCT" >> $GITHUB_OUTPUT
+
+# 커버리지 PR 남기기
+      - name: Post coverage comment PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: jacoco-coverage
+          message: |
+            ## JaCoCo Coverage Report(자코코 커버리지 리포트!)
+            - **CoverageLine(커버리지_라인)** ${{ steps.coverage.outputs.pct }}% (${{ steps.coverage.outputs.covered }} / ${{ steps.coverage.outputs.total }})
+            - **Missed(커버리지_수치)** ${{ steps.coverage.outputs.missed }}
+            - [HTML 리포트](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) (Artifact) 확인하기


### PR DESCRIPTION
CI Coverage 수치를 jacoco XML에서 추출하여 Pull Request 코멘트로 남기는 기능 구현

## 📌 작업 내용
- [x] CI.yml에 PR 코멘트 기능 추가하기

## 🔗 관련 이슈
- Closes #25 

## 🙋 리뷰 요청사항
- 아마 이 부분은 테스트 커버리지를 동작시킬 때 Pull Request 코멘트 형태로 남을겁니다.
- ci.yml 41번째줄부터입니다.
