### PR TITLE
feat(관심사 관리) - 관심사 목록 조회 페이지네이션

### DIFF
--- a/src/main/java/com/codeit/monew/exception/interest/InterestErrorCode.java
+++ b/src/main/java/com/codeit/monew/exception/interest/InterestErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum InterestErrorCode implements ErrorCode {
 
-  INTEREST_NAME_DUPLICATION(HttpStatus.CONFLICT.value(),"유사한 이름의 관심사가 이미 존재합니다.");
+  INTEREST_NAME_DUPLICATION(HttpStatus.CONFLICT.value(),"유사한 이름의 관심사가 이미 존재합니다."),
+
+  INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "관심사를 찾을 수 없습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/com/codeit/monew/exception/subscription/SubscriptionErrorCode.java
+++ b/src/main/java/com/codeit/monew/exception/subscription/SubscriptionErrorCode.java
@@ -1,0 +1,25 @@
+package com.codeit.monew.exception.subscription;
+
+import com.codeit.monew.exception.global.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SubscriptionErrorCode implements ErrorCode {
+
+  ALREADY_SUBSCRIBED(HttpStatus.CONFLICT.value(), "이미 구독한 관심사입니다."),
+  NOT_SUBSCRIBED(HttpStatus.BAD_REQUEST.value(), "구독하지 않은 관심사입니다.");
+
+  private final int status;
+  private final String message;
+
+  SubscriptionErrorCode(int status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  @Override
+  public String getName() {
+    return name();
+  }
+}

--- a/src/main/java/com/codeit/monew/exception/subscription/SubscriptionException.java
+++ b/src/main/java/com/codeit/monew/exception/subscription/SubscriptionException.java
@@ -1,0 +1,15 @@
+package com.codeit.monew.exception.subscription;
+
+import com.codeit.monew.exception.global.ErrorCode;
+import com.codeit.monew.exception.global.MoNewException;
+import java.time.LocalDateTime;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class SubscriptionException extends MoNewException {
+
+  public SubscriptionException(ErrorCode errorCode, Map<String, Object> details) {
+    super(LocalDateTime.now(), errorCode, details);
+  }
+}

--- a/src/main/java/com/codeit/monew/interest/config/QuerydslConfig.java
+++ b/src/main/java/com/codeit/monew/interest/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.codeit.monew.interest.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/codeit/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/codeit/monew/interest/controller/InterestController.java
@@ -1,14 +1,21 @@
 package com.codeit.monew.interest.controller;
 
 import com.codeit.monew.interest.request.InterestRegisterRequest;
+import com.codeit.monew.interest.response_dto.CursorPageResponseInterestDto;
 import com.codeit.monew.interest.response_dto.InterestDto;
 import com.codeit.monew.interest.service.InterestService;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,4 +30,21 @@ public class InterestController {
     InterestDto result = interestService.registerInterest(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(result);
   }
+
+  @GetMapping
+  public ResponseEntity<CursorPageResponseInterestDto> getInterests(
+      @RequestParam(required = false) String keyword,
+      @RequestParam String orderBy,
+      @RequestParam String direction,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime after,
+      @RequestParam int limit,
+      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+  ) {
+    CursorPageResponseInterestDto response = interestService.searchInterests(
+        keyword, orderBy, direction, cursor, after, limit, requestUserId
+    );
+    return ResponseEntity.ok(response);
+  }
+
 }

--- a/src/main/java/com/codeit/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/codeit/monew/interest/controller/InterestController.java
@@ -4,6 +4,8 @@ import com.codeit.monew.interest.request.InterestRegisterRequest;
 import com.codeit.monew.interest.response_dto.CursorPageResponseInterestDto;
 import com.codeit.monew.interest.response_dto.InterestDto;
 import com.codeit.monew.interest.service.InterestService;
+import com.codeit.monew.subscriptions.dto.SubscriptionDto;
+import com.codeit.monew.subscriptions.service.SubscriptionService;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -24,9 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class InterestController {
 
   private final InterestService interestService;
+  private final SubscriptionService subscriptionService;
 
   @PostMapping
-  public ResponseEntity<InterestDto> registerInterest(@RequestBody InterestRegisterRequest request) {
+  public ResponseEntity<InterestDto> registerInterest(
+      @RequestBody InterestRegisterRequest request) {
     InterestDto result = interestService.registerInterest(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(result);
   }
@@ -47,4 +52,12 @@ public class InterestController {
     return ResponseEntity.ok(response);
   }
 
+  @PostMapping("/{interestId}/subscriptions")
+  public ResponseEntity<SubscriptionDto> subscribeInterest(
+      @PathVariable UUID interestId,
+      @RequestHeader("Monew-Request-User-ID") UUID userId
+  ) {
+    SubscriptionDto dto = subscriptionService.subscribe(userId, interestId);
+    return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+  }
 }

--- a/src/main/java/com/codeit/monew/interest/entity/Interest.java
+++ b/src/main/java/com/codeit/monew/interest/entity/Interest.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -25,6 +24,6 @@ public class Interest extends BaseUpdatableEntity {
   @Column(name = "subscriber_count", nullable = false)
   private Integer subscriberCount;
 
-  @Column(name = "deleted_at")
-  private Boolean deletedAt;
+  @Column(name = "is_deleted")
+  private Boolean isDeleted;
 }

--- a/src/main/java/com/codeit/monew/interest/entity/Interest.java
+++ b/src/main/java/com/codeit/monew/interest/entity/Interest.java
@@ -26,4 +26,15 @@ public class Interest extends BaseUpdatableEntity {
 
   @Column(name = "is_deleted")
   private Boolean isDeleted;
+
+  public void increaseSubscriber() {
+    this.subscriberCount += 1;
+  }
+
+  public void decreaseSubscriber() {
+    if (this.subscriberCount == 0) {
+      throw new IllegalStateException("구독자 수는 0보다 작아질 수 없습니다.");
+    }
+    this.subscriberCount -= 1;
+  }
 }

--- a/src/main/java/com/codeit/monew/interest/repository/InterestRepository.java
+++ b/src/main/java/com/codeit/monew/interest/repository/InterestRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface InterestRepository extends JpaRepository<Interest, UUID>, InterestRepositoryCustom{
 
-  List<Interest> findAllByDeletedAtFalse();
+  List<Interest> findAllByIsDeletedFalse();
 
 }
 

--- a/src/main/java/com/codeit/monew/interest/repository/InterestRepository.java
+++ b/src/main/java/com/codeit/monew/interest/repository/InterestRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface InterestRepository extends JpaRepository<Interest, UUID> {
+public interface InterestRepository extends JpaRepository<Interest, UUID>, InterestRepositoryCustom{
 
   List<Interest> findAllByDeletedAtFalse();
 

--- a/src/main/java/com/codeit/monew/interest/repository/InterestRepositoryCustom.java
+++ b/src/main/java/com/codeit/monew/interest/repository/InterestRepositoryCustom.java
@@ -1,0 +1,18 @@
+package com.codeit.monew.interest.repository;
+
+import com.codeit.monew.interest.entity.Interest;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface InterestRepositoryCustom {
+  List<Interest> findInterestsWithCursor(
+      String keyword,
+      String orderBy,
+      String direction,
+      String cursor,
+      LocalDateTime after,
+      int limit
+  );
+}
+
+

--- a/src/main/java/com/codeit/monew/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/interest/repository/InterestRepositoryImpl.java
@@ -29,7 +29,7 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
     OrderSpecifier<?> orderSpecifier = getOrderSpecifier(orderBy, direction, interest);
 
     // 조건 설정
-    BooleanExpression condition = interest.deletedAt.isFalse(); // 삭제되지 않은 것만
+    BooleanExpression condition = interest.isDeleted.isFalse(); // 삭제되지 않은 것만
 
     if (isValid(keyword)) {
       condition = condition.and(interest.name.containsIgnoreCase(keyword));

--- a/src/main/java/com/codeit/monew/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/interest/repository/InterestRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.codeit.monew.interest.repository;
+
+import com.codeit.monew.interest.entity.Interest;
+import com.codeit.monew.interest.entity.QInterest;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class InterestRepositoryImpl implements InterestRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Interest> findInterestsWithCursor(
+      String keyword,
+      String orderBy,
+      String direction,
+      String cursor,
+      LocalDateTime after,
+      int limit
+  ) {
+    QInterest interest = QInterest.interest;
+
+    // 정렬 기준 설정
+    OrderSpecifier<?> orderSpecifier = getOrderSpecifier(orderBy, direction, interest);
+
+    // 조건 설정
+    BooleanExpression condition = interest.deletedAt.isFalse(); // 삭제되지 않은 것만
+
+    if (isValid(keyword)) {
+      condition = condition.and(interest.name.containsIgnoreCase(keyword));
+    }
+
+    if (cursor != null) {
+      condition = condition.and(getCursorCondition(orderBy, direction, cursor, interest));
+    } else if (after != null) {
+      condition = condition.and(interest.createdAt.gt(after));
+    }
+
+    return queryFactory
+        .selectFrom(interest)
+        .where(condition)
+        .orderBy(orderSpecifier)
+        .limit(limit + 1)
+        .fetch();
+  }
+
+  private boolean isValid(String keyword) {
+    return keyword != null && !keyword.trim().isEmpty();
+  }
+
+  private OrderSpecifier<?> getOrderSpecifier(String orderBy, String direction, QInterest interest) {
+    boolean isDesc = "desc".equalsIgnoreCase(direction);
+
+    if ("subscriberCount".equals(orderBy)) {
+      return isDesc ? interest.subscriberCount.desc() : interest.subscriberCount.asc();
+    }
+    return isDesc ? interest.name.desc() : interest.name.asc();
+  }
+
+  private BooleanExpression getCursorCondition(String orderBy, String direction, String cursor, QInterest interest) {
+    boolean isDesc = "desc".equalsIgnoreCase(direction);
+
+    if ("subscriberCount".equals(orderBy)) {
+      int count = Integer.parseInt(cursor);
+      return isDesc ? interest.subscriberCount.lt(count) : interest.subscriberCount.gt(count);
+    }
+    return isDesc ? interest.name.lt(cursor) : interest.name.gt(cursor);
+  }
+}
+
+
+

--- a/src/main/java/com/codeit/monew/interest/repository/KeywordRepository.java
+++ b/src/main/java/com/codeit/monew/interest/repository/KeywordRepository.java
@@ -13,5 +13,7 @@ public interface KeywordRepository extends JpaRepository<Keyword, UUID> {
   List<Keyword> findByInterest(Interest interest); // 기사 쪽에서 쓰임
 
   List<Keyword> findAllByInterest_IdAndDeletedAtFalse(UUID interestId);
+
+  List<Keyword> findByInterestAndDeletedAtFalse(Interest interest);
 }
 

--- a/src/main/java/com/codeit/monew/interest/repository/KeywordRepository.java
+++ b/src/main/java/com/codeit/monew/interest/repository/KeywordRepository.java
@@ -1,19 +1,17 @@
 package com.codeit.monew.interest.repository;
 
-import com.codeit.monew.article.entity.Article;
 import com.codeit.monew.interest.entity.Interest;
 import com.codeit.monew.interest.entity.Keyword;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import software.amazon.awssdk.services.s3.endpoints.internal.Value.Int;
 
 @Repository
 public interface KeywordRepository extends JpaRepository<Keyword, UUID> {
   
   List<Keyword> findByInterest(Interest interest); // 기사 쪽에서 쓰임
-  
+
+  List<Keyword> findAllByInterest_IdAndDeletedAtFalse(UUID interestId);
 }
 

--- a/src/main/java/com/codeit/monew/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/interest/service/InterestService.java
@@ -38,7 +38,7 @@ public class InterestService {
     Interest interest = Interest.builder()
         .name(request.name())
         .subscriberCount(0)
-        .deletedAt(false)
+        .isDeleted(false)
         .build();
 
     Interest savedInterest = interestRepository.save(interest);
@@ -99,7 +99,7 @@ public class InterestService {
 
 
   private void validateSimilarNameExists(String name) {
-    List<Interest> existingInterests = interestRepository.findAllByDeletedAtFalse();
+    List<Interest> existingInterests = interestRepository.findAllByIsDeletedFalse();
 
     for (Interest existingInterest : existingInterests) {
       String existingName = existingInterest.getName();

--- a/src/main/java/com/codeit/monew/subscriptions/dto/SubscriptionDto.java
+++ b/src/main/java/com/codeit/monew/subscriptions/dto/SubscriptionDto.java
@@ -1,0 +1,38 @@
+package com.codeit.monew.subscriptions.dto;
+
+import com.codeit.monew.interest.entity.Interest;
+import com.codeit.monew.interest.entity.Keyword;
+import com.codeit.monew.subscriptions.entity.Subscription;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubscriptionDto {
+  private UUID id;
+  private UUID interestId;
+  private String interestName;
+  private List<String> interestKeywords;
+  private Long interestSubscriberCount;
+  private LocalDateTime createdAt;
+
+  public static SubscriptionDto from(Subscription subscription, List<Keyword> keywords) {
+    Interest interest = subscription.getInterest();
+    return SubscriptionDto.builder()
+        .id(subscription.getId())
+        .interestId(interest.getId())
+        .interestName(interest.getName())
+        .interestKeywords(
+            keywords.stream()
+                .map(Keyword::getKeyword)
+                .collect(Collectors.toList())
+        )
+        .interestSubscriberCount(Long.valueOf(interest.getSubscriberCount()))
+        .createdAt(subscription.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/codeit/monew/subscriptions/entity/Subscription.java
+++ b/src/main/java/com/codeit/monew/subscriptions/entity/Subscription.java
@@ -10,7 +10,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;

--- a/src/main/java/com/codeit/monew/subscriptions/mapper/SubscriptionMapper.java
+++ b/src/main/java/com/codeit/monew/subscriptions/mapper/SubscriptionMapper.java
@@ -1,0 +1,19 @@
+package com.codeit.monew.subscriptions.mapper;
+
+import com.codeit.monew.interest.entity.Keyword;
+import com.codeit.monew.subscriptions.dto.SubscriptionDto;
+import com.codeit.monew.subscriptions.entity.Subscription;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface SubscriptionMapper {
+
+  @Mapping(target = "interestId", expression = "java(subscription.getInterest().getId())")
+  @Mapping(target = "interestName", expression = "java(subscription.getInterest().getName())")
+  @Mapping(target = "interestKeywords", expression = "java(keywords.stream().map(k -> k.getKeyword()).toList())")
+  @Mapping(target = "interestSubscriberCount", expression = "java(Long.valueOf(subscription.getInterest().getSubscriberCount()))")
+  SubscriptionDto toDto(Subscription subscription, List<Keyword> keywords);
+
+}

--- a/src/main/java/com/codeit/monew/subscriptions/repository/SubscriptionRepository.java
+++ b/src/main/java/com/codeit/monew/subscriptions/repository/SubscriptionRepository.java
@@ -1,0 +1,12 @@
+package com.codeit.monew.subscriptions.repository;
+
+import com.codeit.monew.interest.entity.Interest;
+import com.codeit.monew.subscriptions.entity.Subscription;
+import com.codeit.monew.user.entity.User;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
+  boolean existsByUserAndInterest(User user, Interest interest);
+}

--- a/src/main/java/com/codeit/monew/subscriptions/service/SubscriptionService.java
+++ b/src/main/java/com/codeit/monew/subscriptions/service/SubscriptionService.java
@@ -10,6 +10,7 @@ import com.codeit.monew.interest.repository.InterestRepository;
 import com.codeit.monew.interest.repository.KeywordRepository;
 import com.codeit.monew.subscriptions.dto.SubscriptionDto;
 import com.codeit.monew.subscriptions.entity.Subscription;
+import com.codeit.monew.subscriptions.mapper.SubscriptionMapper;
 import com.codeit.monew.subscriptions.repository.SubscriptionRepository;
 import com.codeit.monew.user.entity.User;
 import com.codeit.monew.user.exception.UserErrorCode;
@@ -31,6 +32,8 @@ public class SubscriptionService {
   private final UserRepository userRepository;
   private final InterestRepository interestRepository;
   private final KeywordRepository keywordRepository;
+
+  private final SubscriptionMapper subscriptionMapper;
 
   public SubscriptionDto subscribe(UUID userId, UUID interestId) {
     User user = userRepository.findById(userId)
@@ -60,6 +63,6 @@ public class SubscriptionService {
     // 키워드 직접 조회
     List<Keyword> keywords = keywordRepository.findByInterestAndDeletedAtFalse(interest);
 
-    return SubscriptionDto.from(saved, keywords);
+    return subscriptionMapper.toDto(saved, keywords);
   }
 }

--- a/src/main/java/com/codeit/monew/subscriptions/service/SubscriptionService.java
+++ b/src/main/java/com/codeit/monew/subscriptions/service/SubscriptionService.java
@@ -1,0 +1,65 @@
+package com.codeit.monew.subscriptions.service;
+
+import com.codeit.monew.exception.interest.InterestErrorCode;
+import com.codeit.monew.exception.interest.InterestException;
+import com.codeit.monew.exception.subscription.SubscriptionErrorCode;
+import com.codeit.monew.exception.subscription.SubscriptionException;
+import com.codeit.monew.interest.entity.Interest;
+import com.codeit.monew.interest.entity.Keyword;
+import com.codeit.monew.interest.repository.InterestRepository;
+import com.codeit.monew.interest.repository.KeywordRepository;
+import com.codeit.monew.subscriptions.dto.SubscriptionDto;
+import com.codeit.monew.subscriptions.entity.Subscription;
+import com.codeit.monew.subscriptions.repository.SubscriptionRepository;
+import com.codeit.monew.user.entity.User;
+import com.codeit.monew.user.exception.UserErrorCode;
+import com.codeit.monew.user.exception.UserException;
+import com.codeit.monew.user.repository.UserRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SubscriptionService {
+
+  private final SubscriptionRepository subscriptionRepository;
+  private final UserRepository userRepository;
+  private final InterestRepository interestRepository;
+  private final KeywordRepository keywordRepository;
+
+  public SubscriptionDto subscribe(UUID userId, UUID interestId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(
+            () -> new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId)));
+
+    Interest interest = interestRepository.findById(interestId)
+        .orElseThrow(() -> new InterestException(
+            InterestErrorCode.INTEREST_NOT_FOUND, Map.of("interestId", interestId)));
+
+    if (subscriptionRepository.existsByUserAndInterest(user, interest)) {
+      throw new SubscriptionException(SubscriptionErrorCode.ALREADY_SUBSCRIBED,
+          Map.of("userId", user.getId(), "interestId", interest.getId())
+      );
+    }
+
+    Subscription subscription = Subscription.builder()
+        .user(user)
+        .interest(interest)
+        .build();
+
+    Subscription saved = subscriptionRepository.save(subscription);
+
+    // 구독자 수 증가
+    interest.increaseSubscriber();
+
+    // 키워드 직접 조회
+    List<Keyword> keywords = keywordRepository.findByInterestAndDeletedAtFalse(interest);
+
+    return SubscriptionDto.from(saved, keywords);
+  }
+}

--- a/src/test/java/com/codeit/monew/article/NaverNewsCollectorTest.java
+++ b/src/test/java/com/codeit/monew/article/NaverNewsCollectorTest.java
@@ -160,7 +160,7 @@ class NaverNewsCollectorTest {
     Interest interest = Interest.builder()
         .name("스포츠")
         .subscriberCount(Integer.valueOf(1))
-        .deletedAt(false)
+        .isDeleted(false)
         .build();
 
     when(keywordRepository.findByInterest(interest))

--- a/src/test/java/com/codeit/monew/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/codeit/monew/interest/service/InterestServiceTest.java
@@ -145,6 +145,4 @@ class InterestServiceTest {
         .isDeleted(false)
         .build();
   }
-
-
 }

--- a/src/test/java/com/codeit/monew/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/codeit/monew/interest/service/InterestServiceTest.java
@@ -15,10 +15,14 @@ import com.codeit.monew.interest.repository.KeywordRepository;
 import com.codeit.monew.interest.request.InterestRegisterRequest;
 import com.codeit.monew.interest.response_dto.CursorPageResponseInterestDto;
 import com.codeit.monew.interest.response_dto.InterestDto;
+import com.codeit.monew.subscriptions.repository.SubscriptionRepository;
+import com.codeit.monew.user.entity.User;
+import com.codeit.monew.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +43,12 @@ class InterestServiceTest {
   private KeywordRepository keywordRepository;
 
   @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private SubscriptionRepository subscriptionRepository;
+
+  @Mock
   private InterestMapper interestMapper;
 
   @InjectMocks
@@ -46,6 +56,7 @@ class InterestServiceTest {
 
   private InterestRegisterRequest request;
   private InterestDto expectedDto;
+  private User mockUser;
 
   @BeforeEach
   void setUp() {
@@ -54,6 +65,11 @@ class InterestServiceTest {
         "프로그래밍",
         Arrays.asList("자바", "스프링", "개발")
     );
+
+    mockUser = User.builder()
+        .id(UUID.randomUUID())
+        .email("test@test.com")
+        .build();
 
     // Given - 예상 응답 데이터 준비
     expectedDto = new InterestDto(
@@ -101,6 +117,8 @@ class InterestServiceTest {
     int limit = 2;
     UUID requestUserId = UUID.randomUUID();
 
+    given(userRepository.findById(requestUserId)).willReturn(Optional.of(mockUser));
+
     Interest mockInterest = createMockInterest();
     List<Interest> mockInterests = new ArrayList<>(Arrays.asList(mockInterest, mockInterest, mockInterest));
 
@@ -109,6 +127,9 @@ class InterestServiceTest {
 
     given(keywordRepository.findAllByInterest_IdAndDeletedAtFalse(any()))
         .willReturn(List.of());
+
+    given(subscriptionRepository.existsByUserAndInterest(mockUser, mockInterest)).willReturn(false);
+
 
     InterestDto expectedDto = createMockDto(); // 간단한 mock
     given(interestMapper.toDto(any(), anyList(), eq(false)))

--- a/src/test/java/com/codeit/monew/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/codeit/monew/interest/service/InterestServiceTest.java
@@ -69,7 +69,7 @@ class InterestServiceTest {
   @DisplayName("관심사 등록 요청시 정상적으로 응답 DTO를 반환한다")
   void registerInterest_Success() {
     // Given
-    given(interestRepository.findAllByDeletedAtFalse()).willReturn(List.of());
+    given(interestRepository.findAllByIsDeletedFalse()).willReturn(List.of());
 
     Interest mockInterest = Interest.builder().build();
     given(interestRepository.save(any(Interest.class))).willReturn(mockInterest);
@@ -142,7 +142,7 @@ class InterestServiceTest {
         .name("mock-interest")
         .subscriberCount(100)
         .createdAt(LocalDateTime.now())
-        .deletedAt(false)
+        .isDeleted(false)
         .build();
   }
 

--- a/src/test/java/com/codeit/monew/subscriptions/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/codeit/monew/subscriptions/service/SubscriptionServiceTest.java
@@ -1,0 +1,108 @@
+package com.codeit.monew.subscriptions.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.codeit.monew.interest.entity.Interest;
+import com.codeit.monew.interest.entity.Keyword;
+import com.codeit.monew.interest.repository.InterestRepository;
+import com.codeit.monew.interest.repository.KeywordRepository;
+import com.codeit.monew.subscriptions.dto.SubscriptionDto;
+import com.codeit.monew.subscriptions.entity.Subscription;
+import com.codeit.monew.subscriptions.mapper.SubscriptionMapper;
+import com.codeit.monew.subscriptions.repository.SubscriptionRepository;
+import com.codeit.monew.user.entity.User;
+import com.codeit.monew.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SubscriptionService 테스트")
+class SubscriptionServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private InterestRepository interestRepository;
+
+  @Mock
+  private SubscriptionRepository subscriptionRepository;
+
+  @Mock
+  private KeywordRepository keywordRepository;
+
+  @Mock
+  private SubscriptionMapper subscriptionMapper;
+
+  @InjectMocks
+  private SubscriptionService subscriptionService;
+
+  private UUID userId;
+  private UUID interestId;
+  private User mockUser;
+  private Interest mockInterest;
+
+  @BeforeEach
+  void setUp() {
+    userId = UUID.randomUUID();
+    interestId = UUID.randomUUID();
+
+    mockUser = User.builder()
+        .id(userId)
+        .email("test@test.com")
+        .build();
+
+    mockInterest = Interest.builder()
+        .id(interestId)
+        .name("프로그래밍")
+        .subscriberCount(0)
+        .createdAt(LocalDateTime.now())
+        .isDeleted(false)
+        .build();
+  }
+
+  @Test
+  @DisplayName("구독 요청시 SubscriptionDto를 정상적으로 반환한다")
+  void subscribe_Success() {
+    // Given
+    given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(mockInterest));
+    given(subscriptionRepository.existsByUserAndInterest(mockUser, mockInterest)).willReturn(false);
+
+    Subscription mockSubscription = Subscription.builder()
+        .id(UUID.randomUUID())
+        .user(mockUser)
+        .interest(mockInterest)
+        .createdAt(LocalDateTime.now())
+        .build();
+    given(subscriptionRepository.save(any(Subscription.class))).willReturn(mockSubscription);
+
+    List<Keyword> mockKeywords = List.of(
+        Keyword.builder().id(UUID.randomUUID()).keyword("자바").interest(mockInterest).build(),
+        Keyword.builder().id(UUID.randomUUID()).keyword("스프링").interest(mockInterest).build()
+    );
+    given(keywordRepository.findByInterestAndDeletedAtFalse(mockInterest)).willReturn(mockKeywords);
+
+    // When
+    SubscriptionDto result = subscriptionService.subscribe(userId, interestId);
+
+    // Expected DTO를 subscribe() 후 생성
+    SubscriptionDto expectedDto = subscriptionMapper.toDto(mockSubscription, mockKeywords);
+
+    // Then
+    assertThat(result)
+        .usingRecursiveComparison()
+        .isEqualTo(expectedDto);
+  }
+}


### PR DESCRIPTION
## 📌 작업 내용
- [x] interset 조회 메서드 구현
- [x] 페이지네이션 적용으로 리팩토링
- [x] 목록 조회 테스트 코드 작성
- [x] 관심사 엔티티 변수명 변경

## 🔗 관련 이슈
- Closes #8 

## 🙋 리뷰 요청사항
- 현재 구독기능이 아직 구현되지 않아 구독과 관련된 기능은 임시로 넣어 놨습니다.
- 해당부분은 구독 기능 구현후 리팩토링 하도록 하겠습니다. 