### PR TITLE
feat(뉴스 기사 관리) - 뉴스 기사 목록 조회

### DIFF
--- a/src/main/java/com/codeit/monew/article/controller/ArticleController.java
+++ b/src/main/java/com/codeit/monew/article/controller/ArticleController.java
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/codeit/monew/article/controller/ArticleController.java
+++ b/src/main/java/com/codeit/monew/article/controller/ArticleController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/articles")
 public class ArticleController {

--- a/src/main/java/com/codeit/monew/article/controller/ArticleController.java
+++ b/src/main/java/com/codeit/monew/article/controller/ArticleController.java
@@ -1,16 +1,23 @@
 package com.codeit.monew.article.controller;
 
 
+import com.codeit.monew.article.response_dto.CursorPageResponseArticleDto;
 import com.codeit.monew.article.service.ArticleService;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -35,5 +42,46 @@ public class ArticleController {
     articleService.hardDeleteArticle(UUID.fromString(articleId));
     log.info("기사 삭제 요청 완료 {}", articleId);
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/api/articles")
+  public ResponseEntity<CursorPageResponseArticleDto> getArticles(
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) UUID interestId,
+      @RequestParam(required = false) List<String> sourceIn,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime publishDateFrom,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime publishDateTo,
+      @RequestParam String orderBy,
+      @RequestParam String direction,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime after,
+      @RequestParam int limit,
+      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+  ) {
+    log.info("[GET /api/articles] 요청 시작");
+    log.info("keyword: {}, interestId: {}, sourceIn: {}, publishDateFrom: {}, publishDateTo: {}, orderBy: {}, direction: {}, cursor: {}, after: {}, limit: {}, requestUserId: {}",
+        keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit, requestUserId);
+
+    CursorPageResponseArticleDto response = articleService.articleSearch(
+        keyword,
+        interestId,
+        sourceIn,
+        publishDateFrom,
+        publishDateTo,
+        orderBy,
+        direction,
+        cursor,
+        after,
+        limit,
+        requestUserId
+    );
+
+    // 응답 로그
+    log.info("[GET /api/articles] 요청 완료 - 결과 size: {}, hasNext: {}, nextCursor: {}",
+        response.content().size(),
+        response.hasNext(),
+        response.nextCursor());
+
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/codeit/monew/article/entity/Article.java
+++ b/src/main/java/com/codeit/monew/article/entity/Article.java
@@ -9,16 +9,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "Article")
+@Table(name = "articles")
 @Getter
 @SuperBuilder
 @NoArgsConstructor()
@@ -28,7 +26,7 @@ public class Article extends BaseEntity {
   @Column(name = "source", nullable = false)
   private String source;
 
-  @Column(name = "sourceUrl", nullable = false)
+  @Column(name = "source_url", nullable = false)
   private String sourceUrl;
 
   @Column(name = "article_title", nullable = false)
@@ -47,7 +45,7 @@ public class Article extends BaseEntity {
   private long articleViewCount;
 
   @Setter()
-  @Column(name = "deleted", nullable = false)
+  @Column(name = "is_deleted", nullable = false)
   private boolean deleted;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/codeit/monew/article/entity/ArticlesViewUser.java
+++ b/src/main/java/com/codeit/monew/article/entity/ArticlesViewUser.java
@@ -9,13 +9,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "ArticleViewUsers")
+@Table(name = "article_view_users")
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/codeit/monew/article/mapper/ArticleMapper.java
+++ b/src/main/java/com/codeit/monew/article/mapper/ArticleMapper.java
@@ -1,0 +1,23 @@
+package com.codeit.monew.article.mapper;
+
+
+import com.codeit.monew.article.entity.Article;
+import com.codeit.monew.article.response_dto.ArticleDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring") // 스프링 빈으로 등록
+public interface ArticleMapper {
+
+  @Mapping(source = "article.id", target = "id")
+  @Mapping(source = "article.source", target = "source")
+  @Mapping(source = "article.sourceUrl", target = "sourceUrl")
+  @Mapping(source = "article.articleTitle", target = "title")
+  @Mapping(source = "article.articlePublishDate", target = "publishDate")
+  @Mapping(source = "article.articleSummary", target = "summary")
+  @Mapping(source = "article.articleCommentCount", target = "commentCount")
+  @Mapping(source = "article.articleViewCount", target = "viewCount")
+  @Mapping(source = "viewedByMe", target = "viewedByMe") // 외부 파라미터 매핑
+  ArticleDto toDto(Article article, boolean viewedByMe);
+}

--- a/src/main/java/com/codeit/monew/article/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/com/codeit/monew/article/repository/ArticleRepositoryCustom.java
@@ -1,0 +1,33 @@
+package com.codeit.monew.article.repository;
+
+import com.codeit.monew.article.entity.Article;
+import com.codeit.monew.article.response_dto.CursorPageResponseArticleDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArticleRepositoryCustom {
+
+  List<Article> searchArticles(
+      String keyword,
+      UUID interestId,
+      List<String> sourceIn,
+      LocalDateTime publishDateFrom,
+      LocalDateTime publishDateTo,
+      String orderBy,
+      String direction,
+      String cursor,
+      LocalDateTime after,
+      int limit
+  );
+
+  long searchArticlesCount(
+      String keyword,
+      UUID interestId,
+      List<String> sourceIn,
+      LocalDateTime publishDateFrom,
+      LocalDateTime publishDateTo
+  );
+}

--- a/src/main/java/com/codeit/monew/article/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/article/repository/ArticleRepositoryImpl.java
@@ -1,0 +1,178 @@
+package com.codeit.monew.article.repository;
+
+import com.codeit.monew.article.entity.Article;
+import com.codeit.monew.article.entity.QArticle;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.cglib.core.Local;
+
+public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  public ArticleRepositoryImpl(EntityManager entityManager) {
+    this.queryFactory = new JPAQueryFactory(entityManager);
+  }
+
+  @Override
+  public List<Article> searchArticles(
+      String keyword,
+      UUID interestId,
+      List<String> sourceIn,
+      LocalDateTime publishDateFrom,
+      LocalDateTime publishDateTo,
+      String orderBy,
+      String direction,
+      String cursor,
+      LocalDateTime after,
+      int limit
+  ) {
+    QArticle q = QArticle.article;
+
+    // 1) 기본 조건
+    BooleanBuilder where = new BooleanBuilder();
+    where.and(q.deleted.isFalse());
+
+    if (isValid(keyword)) {
+      where.and(q.articleTitle.containsIgnoreCase(keyword)
+          .or(q.articleSummary.containsIgnoreCase(keyword)));
+    }
+    if (interestId != null) {
+      where.and(q.interest.id.eq(interestId));
+    }
+    if (sourceIn != null && !sourceIn.isEmpty()) {
+      where.and(q.source.in(sourceIn));
+    }
+    if (publishDateFrom != null && publishDateTo != null) {
+      where.and(q.articlePublishDate.between(publishDateFrom, publishDateTo));
+    }
+
+    // 2) 정렬/커서
+    Order dir = isDesc(direction) ? Order.DESC : Order.ASC;
+    List<OrderSpecifier<?>> orders = buildOrderSpecifiers(orderBy, dir, q);
+
+    if (cursor != null && !cursor.isBlank()) {
+      where.and(buildCursorCondition(cursor, orderBy, dir, q, after));
+    } else if (after != null) {
+      where.and(q.createdAt.gt(after));
+    }
+
+    // 3) 조회 (limit + 1은 호출부에서 hasNext 판단 시 사용)
+    List<Article> rows = queryFactory
+        .selectFrom(q)
+        .where(where)
+        .orderBy(orders.toArray(OrderSpecifier[]::new))
+        .limit(limit + 1)
+        .fetch();
+
+    return rows;
+  }
+
+  @Override
+  public long searchArticlesCount (
+      String keyword,
+      UUID interestId,
+      List<String> sourceIn,
+      LocalDateTime publishDateFrom,
+      LocalDateTime publishDateTo
+  ){
+    QArticle q = QArticle.article;
+
+    // 1) 기본 조건
+    BooleanBuilder where = new BooleanBuilder();
+    where.and(q.deleted.isFalse());
+
+    if (isValid(keyword)) {
+      where.and(q.articleTitle.containsIgnoreCase(keyword)
+          .or(q.articleSummary.containsIgnoreCase(keyword)));
+    }
+    if (interestId != null) {
+      where.and(q.interest.id.eq(interestId));
+    }
+    if (sourceIn != null && !sourceIn.isEmpty()) {
+      where.and(q.source.in(sourceIn));
+    }
+    if (publishDateFrom != null && publishDateTo != null) {
+      where.and(q.articlePublishDate.between(publishDateFrom, publishDateTo));
+    }
+
+    Long totalElements = queryFactory
+        .select(q.count())
+        .from(q)
+        .where(where)
+        .fetchOne();
+
+    if (totalElements == null) {
+      totalElements = 0L;  // null일 경우 기본값 처리
+    }
+    return totalElements;
+  }
+
+  private boolean isValid(String s) {
+    return s != null && !s.trim().isEmpty();
+  }
+
+  private boolean isDesc(String direction) {
+    return "DESC".equalsIgnoreCase(direction);
+  }
+
+  private List<OrderSpecifier<?>> buildOrderSpecifiers(String orderBy, Order dir, QArticle q) {
+    List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+    switch (orderBy == null ? "" : orderBy) {
+      case "commentCount":
+        orders.add(new OrderSpecifier<>(dir, q.articleCommentCount));
+        break;
+      case "viewCount":
+        orders.add(new OrderSpecifier<>(dir, q.articleViewCount));
+        break;
+      case "publishDate":
+        orders.add(new OrderSpecifier<>(dir, q.articlePublishDate));
+        break;
+      default:
+        orders.add(new OrderSpecifier<>(Order.DESC, q.createdAt));
+        break;
+    }
+
+    orders.add(new OrderSpecifier<>(dir, q.createdAt));
+    return orders;
+  }
+
+  private BooleanExpression buildCursorCondition(String cursor, String orderBy, Order dir, QArticle qArticle, LocalDateTime after) {
+    // 비교 헬퍼
+    switch (orderBy == null ? "" : orderBy) {
+      case "commentCount": {
+        BooleanExpression primaryCmp =
+            (dir == Order.DESC) ? qArticle.articleCommentCount.lt(Long.valueOf(cursor))
+                : qArticle.articleCommentCount.gt(Long.valueOf(cursor));
+        return primaryCmp
+            .or(qArticle.createdAt.eq(after).or(qArticle.createdAt.after(after)));
+      }
+      case "viewCount": {
+        BooleanExpression primaryCmp =
+            (dir == Order.DESC) ? qArticle.articleViewCount.lt(Long.valueOf(cursor))
+                : qArticle.articleViewCount.gt(Long.valueOf(cursor));
+        return primaryCmp
+            .or(qArticle.createdAt.eq(after).or(qArticle.createdAt.after(after)));
+      }
+      case "publishDate": {
+        BooleanExpression primaryCmp =
+            (dir == Order.DESC) ? qArticle.articlePublishDate.lt(LocalDateTime.parse(cursor))
+                : qArticle.articlePublishDate.gt(LocalDateTime.parse(cursor));
+        return primaryCmp
+            .or(qArticle.createdAt.eq(after).or(qArticle.createdAt.after(after)));
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/codeit/monew/article/repository/ArticleViewUserRepository.java
+++ b/src/main/java/com/codeit/monew/article/repository/ArticleViewUserRepository.java
@@ -1,16 +1,15 @@
 package com.codeit.monew.article.repository;
 
 import com.codeit.monew.article.entity.Article;
+import com.codeit.monew.article.entity.ArticlesViewUser;
 import com.codeit.monew.interest.entity.Interest;
+import com.codeit.monew.user.entity.User;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ArticleRepository extends JpaRepository<Article, UUID>, ArticleRepositoryCustom {
-
-  Optional<Article> findTop1ByInterestOrderByArticlePublishDateDesc(Interest interest);
-  Optional<Article> findBySourceUrl(String sourceUrl);
-
+public interface ArticleViewUserRepository extends JpaRepository<ArticlesViewUser, UUID> {
+  boolean existsByArticleAndUser(Article article, User user);
 }

--- a/src/main/java/com/codeit/monew/article/response_dto/CursorPageResponseArticleDto.java
+++ b/src/main/java/com/codeit/monew/article/response_dto/CursorPageResponseArticleDto.java
@@ -2,9 +2,10 @@ package com.codeit.monew.article.response_dto;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 
 public record CursorPageResponseArticleDto(
-  ArrayList<ArticleDto> content,
+  List<ArticleDto> content,
   String nextCursor,
   LocalDateTime nextAfter,
   int size,

--- a/src/main/java/com/codeit/monew/article/service/ArticleService.java
+++ b/src/main/java/com/codeit/monew/article/service/ArticleService.java
@@ -67,7 +67,7 @@ public class ArticleService {
         keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit, requestUserId);
 
     List<Article> articles = articleRepository.searchArticles(keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit);
-    List<ArticleDto> content = null;
+    List<ArticleDto> content = new ArrayList<>();
     Optional<User> user = userRepository.findById(requestUserId); // npe 날 수 있으니 예외 처리, 충돌을 우려하며 나중에 유저 쪽 코드랑 머지 되었을 때 예외 처리 추가
 
     if (articles.size() > limit) {

--- a/src/main/java/com/codeit/monew/article/service/ArticleService.java
+++ b/src/main/java/com/codeit/monew/article/service/ArticleService.java
@@ -1,30 +1,39 @@
 package com.codeit.monew.article.service;
 
 import com.codeit.monew.article.entity.Article;
+import com.codeit.monew.article.mapper.ArticleMapper;
 import com.codeit.monew.article.repository.ArticleRepository;
+import com.codeit.monew.article.repository.ArticleViewUserRepository;
+import com.codeit.monew.article.response_dto.ArticleDto;
 import com.codeit.monew.article.response_dto.CursorPageResponseArticleDto;
 import com.codeit.monew.exception.article.ArticleException;
 import com.codeit.monew.exception.article.ArticleNotFoundException;
+import com.codeit.monew.user.entity.User;
+import com.codeit.monew.user.repository.UserRepository;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 @Transactional
 public class ArticleService {
 
   private final ArticleRepository articleRepository;
-
-  public ArticleService(ArticleRepository articleRepository) {
-    this.articleRepository = articleRepository;
-  }
+  private final ArticleMapper articleMapper;
+  private final ArticleViewUserRepository articleViewUserRepository;
+  private final UserRepository userRepository;
 
   public void softDeleteArticle(UUID articleId) {
     log.info("기사 논리 삭제 시작 {}", articleId);
@@ -57,10 +66,42 @@ public class ArticleService {
     log.info("뉴스 기사 검색 시작 - keyword={}, interestId={}, sourceIn={}, publishDateFrom={}, publishDateTo={}, orderBy={}, direction={}, cursor={}, after={}, limit={}, requestUserId={}",
         keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit, requestUserId);
 
+    List<Article> articles = articleRepository.searchArticles(keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit);
+    List<ArticleDto> content = null;
+    Optional<User> user = userRepository.findById(requestUserId); // npe 날 수 있으니 예외 처리, 충돌을 우려하며 나중에 유저 쪽 코드랑 머지 되었을 때 예외 처리 추가
 
+    if (articles.size() > limit) {
+      articles = articles.subList(0, limit);
+    }
+
+    for (Article article : articles) {
+      boolean viewed = articleViewUserRepository.existsByArticleAndUser(article, user.get());
+      ArticleDto dto = articleMapper.toDto(article, viewed);
+      content.add(dto);
+    }
+
+    String nextCursor = null;
+    LocalDateTime nextAfter = null;
+    switch (orderBy == null ? "" : orderBy) {
+      case "commentCount":
+        nextCursor = articles.size() == limit+1 ? String.valueOf(articles.get(limit).getArticleCommentCount()) : null;
+        nextAfter = articles.size() == limit+1 ? articles.get(limit).getCreatedAt() : null;
+        break;
+      case "viewCount":
+        nextCursor = articles.size() == limit+1 ? String.valueOf(articles.get(limit).getArticleViewCount()) : null;
+        nextAfter = articles.size() == limit+1 ? articles.get(limit).getCreatedAt() : null;
+        break;
+      case "publishDate":
+        nextCursor = articles.size() == limit+1 ? String.valueOf(articles.get(limit).getArticlePublishDate()) : null;
+        nextAfter = articles.size() == limit+1 ? articles.get(limit).getCreatedAt() : null;
+        break;
+    }
+    int size = articles.size();
+    long totalElements = articleRepository.searchArticlesCount(keyword, interestId, sourceIn, publishDateFrom, publishDateTo);
+    boolean hasNex = size == limit+1;
 
     log.info("뉴스 기사 검색 완료");
-    return null;
+    return new CursorPageResponseArticleDto(content, nextCursor, nextAfter, size, totalElements, hasNex);
   }
 
   private Article checkArticle(UUID articleId) {

--- a/src/main/java/com/codeit/monew/base/entity/BaseEntity.java
+++ b/src/main/java/com/codeit/monew/base/entity/BaseEntity.java
@@ -30,6 +30,6 @@ public abstract class BaseEntity {
   private UUID id;
 
   @CreatedDate
-  @Column(name = "createdAt", updatable = false, nullable = false)
+  @Column(name = "created_at", updatable = false, nullable = false)
   private LocalDateTime createdAt;
 }

--- a/src/main/java/com/codeit/monew/base/entity/BaseUpdatableEntity.java
+++ b/src/main/java/com/codeit/monew/base/entity/BaseUpdatableEntity.java
@@ -19,6 +19,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseUpdatableEntity extends BaseEntity {
 
   @LastModifiedDate
-  @Column(name = "updatedAt", nullable = false)
+  @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/codeit/monew/comment/entity/Comment.java
+++ b/src/main/java/com/codeit/monew/comment/entity/Comment.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "Comments")
+@Table(name = "comments")
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/codeit/monew/comment/entity/CommentLike.java
+++ b/src/main/java/com/codeit/monew/comment/entity/CommentLike.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "Comment_likes")
+@Table(name = "comment_likes")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/codeit/monew/global/config/QuerydslConfig.java
+++ b/src/main/java/com/codeit/monew/global/config/QuerydslConfig.java
@@ -1,4 +1,4 @@
-package com.codeit.monew.interest.config;
+package com.codeit.monew.global.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/src/main/java/com/codeit/monew/interest/entity/Keyword.java
+++ b/src/main/java/com/codeit/monew/interest/entity/Keyword.java
@@ -9,13 +9,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "keyword")
+@Table(name = "keywords")
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/codeit/monew/notification/entity/Notification.java
+++ b/src/main/java/com/codeit/monew/notification/entity/Notification.java
@@ -13,14 +13,13 @@ import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "Notification")
+@Table(name = "notifications")
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/codeit/monew/subscriptions/entity/Subscription.java
+++ b/src/main/java/com/codeit/monew/subscriptions/entity/Subscription.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "subscription")
+@Table(name = "subscriptions")
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/test/java/com/codeit/monew/article/ArticleServiceTest.java
+++ b/src/test/java/com/codeit/monew/article/ArticleServiceTest.java
@@ -6,23 +6,33 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import com.codeit.monew.article.mapper.ArticleMapper;
+import com.codeit.monew.article.repository.ArticleViewUserRepository;
+import com.codeit.monew.article.response_dto.ArticleDto;
+import com.codeit.monew.article.response_dto.CursorPageResponseArticleDto;
 import com.codeit.monew.article.service.ArticleService;
 import com.codeit.monew.exception.article.ArticleNotFoundException;
 import com.codeit.monew.interest.entity.Interest;
+import com.codeit.monew.user.entity.User;
+import com.codeit.monew.user.repository.UserRepository;
 import jakarta.persistence.criteria.CriteriaBuilder.In;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import com.codeit.monew.article.entity.Article;
 import com.codeit.monew.article.repository.ArticleRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ArticleServiceTest {
@@ -30,12 +40,21 @@ class ArticleServiceTest {
   @Mock
   ArticleRepository articleRepository;
 
+  @Mock
+  ArticleViewUserRepository articleViewUserRepository;
+
+  @Mock
+  UserRepository userRepository;
+
+  @Mock
+  ArticleMapper articleMapper;
+
   @InjectMocks
-  ArticleService service; // 실제 서비스 클래스명으로 변경
+  ArticleService articleService; // 실제 서비스 클래스명으로 변경
 
   @Test
-  @DisplayName("기사 논리 삭제")
-  void softDeleteArticle_marksDeleted_andSaves() {
+  @DisplayName("기사 논리 삭제 테스트")
+  void softDeleteArticle() {
     // Given
     UUID id = UUID.randomUUID();
     Article article = Article.builder()
@@ -44,7 +63,7 @@ class ArticleServiceTest {
     given(articleRepository.findById(id)).willReturn(Optional.of(article));
 
     // When
-    service.softDeleteArticle(id);
+    articleService.softDeleteArticle(id);
 
     // Then
     assertThat(article.isDeleted()).isTrue();
@@ -53,8 +72,8 @@ class ArticleServiceTest {
   }
 
   @Test
-  @DisplayName("기사 물리 삭제")
-  void hardDeleteArticle_marksDeleted_andSaves() {
+  @DisplayName("기사 물리 삭제 테스트")
+  void hardDeleteArticle() {
     // Given
     UUID id = UUID.randomUUID();
     Interest interest = Interest.builder().name("test").subscriberCount(0).build();
@@ -78,7 +97,7 @@ class ArticleServiceTest {
     Article saved = articleRepository.save(article);
 
     // When
-    service.hardDeleteArticle(id);
+    articleService.hardDeleteArticle(id);
 
     // Then: 삭제 로직이 delete(...)를 호출했는지 검증
     then(articleRepository).should().delete(article);
@@ -87,17 +106,97 @@ class ArticleServiceTest {
   }
 
   @Test
-  @DisplayName("deleteArticle: 기사가 없으면 ArticleNotFoundException을 던지고 save는 호출되지 않는다")
-  void deleteArticle_throws_whenNotFound_andNoSave() {
+  @DisplayName("기사 삭제시 기사가 없으면 예외 발생 테스트")
+  void deleteArticleThrowsWhenNotFoundAndNoSave() {
     // Given
     UUID id = UUID.randomUUID();
     given(articleRepository.findById(id)).willReturn(Optional.empty());
 
     // When / Then
-    assertThatThrownBy(() -> service.softDeleteArticle(id))
+    assertThatThrownBy(() -> articleService.softDeleteArticle(id))
         .isInstanceOf(ArticleNotFoundException.class);
 
     then(articleRepository).should().findById(id);
     then(articleRepository).should(never()).save(org.mockito.Mockito.any());
+  }
+  
+  @Test
+  @DisplayName("기사 목록 조회 테스트")
+  void searchArticles() {
+    // given
+    String keyword = "스포츠";
+    UUID interestId = UUID.randomUUID();
+    List<String> sourceIn = List.of("NAVER");
+    LocalDateTime publishDateFrom = LocalDateTime.now().minusDays(7);
+    LocalDateTime publishDateTo = LocalDateTime.now();
+    String orderBy = "viewCount";
+    String direction = "DESC";
+    String cursor = null;
+    LocalDateTime after = null;
+    int limit = 2;
+
+    // 기사 3개 (limit+1) → hasNext = true
+    Article article1 = Article.builder()
+        .id(UUID.randomUUID())
+        .articleTitle("A1")
+        .articleViewCount(500)
+        .articleCommentCount(10)
+        .articlePublishDate(publishDateTo.minusHours(1))
+        .createdAt(publishDateTo.minusHours(1))
+        .build();
+
+    Article article2 = Article.builder()
+        .id(UUID.randomUUID())
+        .articleTitle("A2")
+        .articleViewCount(450)
+        .articleCommentCount(20)
+        .articlePublishDate(publishDateTo.minusHours(2))
+        .createdAt(publishDateTo.minusHours(2))
+        .build();
+
+    Article article3 = Article.builder()
+        .id(UUID.randomUUID())
+        .articleTitle("A3")
+        .articleViewCount(440)
+        .articleCommentCount(30)
+        .articlePublishDate(publishDateTo.minusHours(3))
+        .createdAt(publishDateTo.minusHours(3))
+        .build();
+
+    List<Article> fetched = List.of(article1, article2, article3);
+
+    when(articleRepository.searchArticles(keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit
+    )).thenReturn(fetched);
+
+    // ★ 여기서 만든 requestUserId를 아래 서비스 호출에도 "그대로" 사용해야 함
+    UUID requestUserId = UUID.randomUUID();
+    User user = User.builder().id(requestUserId).nickname("test").build();
+    when(userRepository.findById(requestUserId)).thenReturn(Optional.of(user));
+
+    // 조회 여부 (실제 매핑은 잘라낸 2건만 수행됨)
+    when(articleViewUserRepository.existsByArticleAndUser(article1, user)).thenReturn(true);
+    when(articleViewUserRepository.existsByArticleAndUser(article2, user)).thenReturn(false);
+    // article3는 초과분이라 호출되지 않음
+
+    // totalElements 스텁
+    when(articleRepository.searchArticlesCount(
+        keyword, interestId, sourceIn, publishDateFrom, publishDateTo
+    )).thenReturn(3L);
+
+    when(articleMapper.toDto(article1, true))
+        .thenReturn(new ArticleDto(article1.getId(), article1.getSource(), article1.getSourceUrl(), article1.getArticleTitle(), article1.getArticlePublishDate(), article1.getArticleSummary(), article1.getArticleCommentCount(), article1.getArticleViewCount(), true));
+
+    when(articleMapper.toDto(article2, false))
+        .thenReturn(new ArticleDto(article2.getId(), article2.getSource(), article2.getSourceUrl(), article2.getArticleTitle(), article2.getArticlePublishDate(), article2.getArticleSummary(), article2.getArticleCommentCount(), article2.getArticleViewCount(), false));
+
+    // when  ★ requestUserId 변수를 그대로 사용 (UUID.randomUUID() 쓰면 스텁 미스매치 발생)
+    CursorPageResponseArticleDto res = articleService.articleSearch(
+        keyword, interestId, sourceIn, publishDateFrom, publishDateTo,
+        orderBy, direction, cursor, after, limit, requestUserId
+    );
+
+    // then
+    assertThat(res.content()).hasSize(2);      // limit 만큼만
+
   }
 }


### PR DESCRIPTION
## 📌 작업 내용
- [X] 하나의 검색어로 다음의 속성 중 하나라도 부분일치하는 데이터를 검색할 수 있습니다.
    - 제목, 요약
- [X] 다음의 속성으로 조회할 수 있습니다.
    - 관심사, 출처, 날짜
    - 조회 조건이 여러 개인 경우 모든 조건을 만족한 결과로 조회합니다.
- [X] 다음의 속성으로 정렬 및 커서 페이지네이션을 구현합니다.
    - 날짜, 댓글 수, 조회 수
    - 선택적으로 1개의 정렬 조건만 가질 수 있습니다.
- [X] - 뉴스 기사 목록 조회 테스트 코드 작성
## 🔗 관련 이슈
- Closes #15 
