### PR TITLE
feat(관심사 관리) : 관심사 구독 삭제

### DIFF
--- a/src/main/java/com/codeit/monew/exception/subscription/SubscriptionErrorCode.java
+++ b/src/main/java/com/codeit/monew/exception/subscription/SubscriptionErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum SubscriptionErrorCode implements ErrorCode {
 
   ALREADY_SUBSCRIBED(HttpStatus.CONFLICT.value(), "이미 구독한 관심사입니다."),
-  NOT_SUBSCRIBED(HttpStatus.BAD_REQUEST.value(), "구독하지 않은 관심사입니다.");
+  NOT_SUBSCRIBED(HttpStatus.NOT_FOUND.value(), "구독하지 않은 관심사입니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/com/codeit/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/codeit/monew/interest/controller/InterestController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -59,5 +60,14 @@ public class InterestController {
   ) {
     SubscriptionDto dto = subscriptionService.subscribe(userId, interestId);
     return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+  }
+
+  @DeleteMapping("/{interestId}/subscriptions")
+  public ResponseEntity<Void> unsubscribe(
+      @PathVariable UUID interestId,
+      @RequestHeader("Monew-Request-User-ID") UUID userId
+  ) {
+    subscriptionService.unsubscribe(userId, interestId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/codeit/monew/subscriptions/repository/SubscriptionRepository.java
+++ b/src/main/java/com/codeit/monew/subscriptions/repository/SubscriptionRepository.java
@@ -3,10 +3,15 @@ package com.codeit.monew.subscriptions.repository;
 import com.codeit.monew.interest.entity.Interest;
 import com.codeit.monew.subscriptions.entity.Subscription;
 import com.codeit.monew.user.entity.User;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
+
   boolean existsByUserAndInterest(User user, Interest interest);
+
+  Optional<Subscription> findByUserAndInterest(User user, Interest interest);
+
 }

--- a/src/main/java/com/codeit/monew/subscriptions/service/SubscriptionService.java
+++ b/src/main/java/com/codeit/monew/subscriptions/service/SubscriptionService.java
@@ -65,4 +65,26 @@ public class SubscriptionService {
 
     return subscriptionMapper.toDto(saved, keywords);
   }
+
+  public void unsubscribe(UUID userId, UUID interestId) {
+    // 1. 사용자 조회
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId)));
+
+    // 2. 관심사 조회
+    Interest interest = interestRepository.findById(interestId)
+        .orElseThrow(() -> new InterestException(InterestErrorCode.INTEREST_NOT_FOUND, Map.of("interestId", interestId)));
+
+    // 3. 구독 조회
+    Subscription subscription = subscriptionRepository.findByUserAndInterest(user, interest)
+        .orElseThrow(() -> new SubscriptionException(SubscriptionErrorCode.NOT_SUBSCRIBED,
+            Map.of("userId", userId, "interestId", interestId)));
+
+    // 4. 구독 삭제
+    subscriptionRepository.delete(subscription);
+
+    // 5. 구독자 수 감소
+    interest.decreaseSubscriber();
+  }
+
 }

--- a/src/test/java/com/codeit/monew/subscriptions/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/codeit/monew/subscriptions/service/SubscriptionServiceTest.java
@@ -105,4 +105,30 @@ class SubscriptionServiceTest {
         .usingRecursiveComparison()
         .isEqualTo(expectedDto);
   }
+
+  @Test
+  @DisplayName("구독 취소시 정상적으로 구독이 삭제되고 구독자 수가 감소한다")
+  void unsubscribe_Success() {
+    // Given
+    Subscription mockSubscription = Subscription.builder()
+        .id(UUID.randomUUID())
+        .user(mockUser)
+        .interest(mockInterest)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    // 구독 되어 있는 상태
+    mockInterest.increaseSubscriber();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(mockInterest));
+    given(subscriptionRepository.findByUserAndInterest(mockUser, mockInterest))
+        .willReturn(Optional.of(mockSubscription));
+
+    // When
+    subscriptionService.unsubscribe(userId, interestId);
+
+    // Then
+    assertThat(mockInterest.getSubscriberCount()).isZero();
+  }
 }


### PR DESCRIPTION
## 📌 작업 내용
- [x] 구독한 관심사 취소하는 메서드 구현
- [x] 구독취소 테스트 코드 구현

## 🔗 관련 이슈
- Closes #26 

## 🐛 에러 상황 및 원인 (선택)
- 

## 🙋 리뷰 요청사항
- rebase 해결때문에 커밋 파일이 많습니다.
- interest 부분과 subscriptions 관련된 부분만 확인해 주시면 될것 같습니다.