### PR TITLE
feat(사용자 관리): 사용자 삭제 기능 추가 

### DIFF
--- a/src/main/java/com/codeit/monew/user/controller/UserController.java
+++ b/src/main/java/com/codeit/monew/user/controller/UserController.java
@@ -45,4 +45,11 @@ public class UserController {
     userService.softDelete(userId);
     return ResponseEntity.noContent().build();
   }
+
+  // 클라이언트에 노출x
+  @DeleteMapping("/{userId}/hard")
+  public ResponseEntity<Void> shardDeleteUser(@PathVariable UUID userId) {
+    userService.hardDelete(userId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/codeit/monew/user/exception/UserErrorCode.java
+++ b/src/main/java/com/codeit/monew/user/exception/UserErrorCode.java
@@ -11,8 +11,9 @@ public enum UserErrorCode implements ErrorCode {
 
   USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "회원이 존재하지 않습니다."),
   USER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST.value(), "이메일이 중복되었습니다."),
-  USER_LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), "로그인에 실패했습니다.");
-
+  USER_LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), "로그인에 실패했습니다."),
+  USER_NOT_DELETABLE(HttpStatus.BAD_REQUEST.value(), "삭제 대상이 아닙니다."),
+  USER_HARD_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "사용자 물리 삭제 실패");
   private final int status;
   private final String message;
 

--- a/src/main/java/com/codeit/monew/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/monew/user/repository/UserRepository.java
@@ -2,11 +2,17 @@ package com.codeit.monew.user.repository;
 
 import com.codeit.monew.user.entity.User;
 import java.util.Optional;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
   boolean existsByEmail(String email);
 
   Optional<User> findByEmail(String email);
+
+  @Query("SELECT u FROM User u WHERE u.userStatus = 'DELETED' AND u.deletedAt <= :now")
+  List<User> findUsersForHardDelete(LocalDateTime now);
 }

--- a/src/main/java/com/codeit/monew/user/scheduler/UserCleanUpScheduler.java
+++ b/src/main/java/com/codeit/monew/user/scheduler/UserCleanUpScheduler.java
@@ -1,0 +1,40 @@
+package com.codeit.monew.user.scheduler;
+
+import com.codeit.monew.user.entity.User;
+import com.codeit.monew.user.exception.UserErrorCode;
+import com.codeit.monew.user.exception.UserException;
+import com.codeit.monew.user.repository.UserRepository;
+import com.codeit.monew.user.service.UserService;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserCleanUpScheduler {
+
+  private final UserRepository userRepository;
+
+  private final UserService userService;
+
+  //환경 변수로 변경 예정
+  @Scheduled(cron = "0 * * * * *")
+  public void cleanUpSoftDeletedUser() {
+    List<User> deletedUsers = userRepository.findUsersForHardDelete(LocalDateTime.now().minusMinutes(5));
+
+    for(User user : deletedUsers) {
+      try {
+        userService.hardDelete(user.getId());
+      } catch(UserException e) {
+        String message = String.format("%s 물리 삭제 실패",user.getId().toString());
+        throw new UserException(UserErrorCode.USER_HARD_DELETE_FAILED, Map.of("user", message));
+      }
+    }
+
+  }
+
+}

--- a/src/main/java/com/codeit/monew/user/service/UserService.java
+++ b/src/main/java/com/codeit/monew/user/service/UserService.java
@@ -88,4 +88,22 @@ public class UserService {
     return userStatus.equals(UserStatus.DELETED);
   }
 
+  public void hardDelete(UUID userId) {
+    User hardDeletedUser = userRepository.findById(userId)
+        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId)));
+
+    if(!isUserStatusDeleted(hardDeletedUser.getUserStatus())) {
+      throw new UserException(UserErrorCode.USER_NOT_DELETABLE, Map.of("userId", userId));
+    }
+
+    if(isSoftDeletedBeforeFiveMinutes(hardDeletedUser.getDeletedAt())) {
+      userRepository.delete(hardDeletedUser);
+    }
+  }
+
+  //프로토 타입용으로 5분으로 설정
+  private boolean isSoftDeletedBeforeFiveMinutes(LocalDateTime deletedAt) {
+    return deletedAt.isBefore(LocalDateTime.now().minusMinutes(5)) ||
+        deletedAt.isEqual(LocalDateTime.now().minusMinutes(5));
+  }
 }

--- a/src/test/java/com/codeit/monew/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/monew/user/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.codeit.monew.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
@@ -132,6 +133,29 @@ public class UserServiceTest {
     //then
     then(userRepository).should(times(1)).findById(any(UUID.class));
     then(userRepository).should(times(1)).save(any(User.class));
+
+  }
+
+  @Test
+  @DisplayName("사용자 물리 삭제에 성공한다")
+  void deleteHardDelete_Success() {
+    //given
+    User softDeletedUser = User.builder()
+        .email("email@email.com")
+        .nickname("test")
+        .password(BCrypt.withDefaults().hashToString(12, "password".toCharArray()))
+        .userStatus(UserStatus.DELETED)
+        .deletedAt(LocalDateTime.now().minusMinutes(5))
+        .build();
+
+    given(userRepository.findById(any(UUID.class))).willReturn(Optional.of(softDeletedUser));
+
+    //when
+    userService.hardDelete(userId);
+
+    //then
+    then(userRepository).should(times(1)).findById(any(UUID.class));
+    then(userRepository).should(times(1)).delete(eq(softDeletedUser));
 
   }
 


### PR DESCRIPTION
## 📌 작업 내용
- [x] 사용자 존재성 검사
- [x] 논리 삭제 후 1일 뒤 물리 삭제
  - [x] 개발 환경에서는 5분으로 설정 
- [x] 물리 삭제 시 관련 정보 모두 삭제

## 🔗 관련 이슈
- Closes #7 

## 🐛 에러 상황 및 원인 (선택)

## 🙋 리뷰 요청사항
- 배치 시간은 추후에 환경변수로 주입할 예정입니다
- 배치 도입은 추후에 고려하겠습니다