### PR TITLE
fix(뉴스 기사 관리): 네이버 기사 수집시 오류 수정

### DIFF
--- a/src/main/java/com/codeit/monew/article/entity/Article.java
+++ b/src/main/java/com/codeit/monew/article/entity/Article.java
@@ -26,7 +26,7 @@ public class Article extends BaseEntity {
   @Column(name = "source", nullable = false)
   private String source;
 
-  @Column(name = "source_url", nullable = false)
+  @Column(name = "source_url", length = 1024 ,nullable = false)
   private String sourceUrl;
 
   @Column(name = "article_title", nullable = false)

--- a/src/main/java/com/codeit/monew/article/rss/ChoSunCollector.java
+++ b/src/main/java/com/codeit/monew/article/rss/ChoSunCollector.java
@@ -40,7 +40,7 @@ public class ChoSunCollector {
 
   @Transactional
   //@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 시간 정각 마다
-  @Scheduled(cron = "2 * * * * *", zone = "Asia/Seoul")// 매 분 마다
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 분 마다
   public void chousunArticleFetchAndSaveHourly() throws Exception {
     log.info("조선일보 기사 수집 스케줄링 수집 시작: {}", LocalDateTime.now());
     List<Interest> interests = interestRepository.findAll();

--- a/src/main/java/com/codeit/monew/article/rss/HankyungCollector.java
+++ b/src/main/java/com/codeit/monew/article/rss/HankyungCollector.java
@@ -39,7 +39,7 @@ public class HankyungCollector {
 
   @Transactional
   //@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 시간 정각 마다
-  @Scheduled(cron = "2 * * * * *", zone = "Asia/Seoul")// 매 분 마다
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 분 마다
   public void hankyungArticleFetchAndSaveHourly() throws Exception {
     log.info("한국경제 기사 수집 스케줄링 수집 시작: {}", LocalDateTime.now());
     List<Interest> interests = interestRepository.findAll();

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -13,3 +13,9 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
+
+naver:
+  api:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
       path: /h2-console   # 접속 경로
   datasource:
     url: jdbc:h2:mem:Monew;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.postgresql.Driver
+    driver-class-name: org.h2.Driver
     username: sa
     password:
   jpa:


### PR DESCRIPTION
## 📌 작업 내용
- 네이버 기사 요청 API에 있던 파리터값을 옳은 값을 유지하도록 변경, 기사 발행일 일자 변경 오류 수정, 원본 기사 URL길이가 너무 길 때 생기는 오류에 대해서 기사 엔티티의 URL길이 제한 512로 변경

## 🔗 관련 이슈
- Closes #86 

## 🐛 에러 상황 및 원인 (선택)
- 일부 기사의 url이 255자를 넘겨서 발생
- 네이버 API 요청할 때 넘겨줘야 할 값에 허용 범위 값을 초과하여 에러 발생
- 기사 발행일을 서로 비교하는 부분을 반대로 적용 
