### PR TITLE
fix(뉴스 기사 관리): 뉴스 기사 목록 조회 오류 수정

### DIFF
--- a/src/main/java/com/codeit/monew/article/naver/NaverNewsCollector.java
+++ b/src/main/java/com/codeit/monew/article/naver/NaverNewsCollector.java
@@ -68,8 +68,7 @@ public class NaverNewsCollector {
   }
 
   @Transactional
-  //@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 시간 정각 마다
-  @Scheduled(cron = "1 * * * * *", zone = "Asia/Seoul")// 매 분 마다
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
   public void fetchAndSaveHourly() throws InterruptedException {
     log.info("네이버 기사 수집 스케줄링 수집 시작: {}", LocalDateTime.now());
     int display = 100;

--- a/src/main/java/com/codeit/monew/article/rss/ChoSunCollector.java
+++ b/src/main/java/com/codeit/monew/article/rss/ChoSunCollector.java
@@ -39,8 +39,7 @@ public class ChoSunCollector {
   private final KeywordRepository keywordRepository;
 
   @Transactional
-  //@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 시간 정각 마다
-  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 분 마다
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
   public void chousunArticleFetchAndSaveHourly() throws Exception {
     log.info("조선일보 기사 수집 스케줄링 수집 시작: {}", LocalDateTime.now());
     List<Interest> interests = interestRepository.findAll();

--- a/src/main/java/com/codeit/monew/article/rss/HankyungCollector.java
+++ b/src/main/java/com/codeit/monew/article/rss/HankyungCollector.java
@@ -38,8 +38,7 @@ public class HankyungCollector {
   private final KeywordRepository keywordRepository;
 
   @Transactional
-  //@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 시간 정각 마다
-  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 분 마다
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
   public void hankyungArticleFetchAndSaveHourly() throws Exception {
     log.info("한국경제 기사 수집 스케줄링 수집 시작: {}", LocalDateTime.now());
     List<Interest> interests = interestRepository.findAll();

--- a/src/main/java/com/codeit/monew/article/service/ArticleService.java
+++ b/src/main/java/com/codeit/monew/article/service/ArticleService.java
@@ -68,6 +68,8 @@ public class ArticleService {
     log.info("뉴스 기사 검색 시작 - keyword={}, interestId={}, sourceIn={}, publishDateFrom={}, publishDateTo={}, orderBy={}, direction={}, cursor={}, after={}, limit={}, requestUserId={}",
         keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit, requestUserId);
 
+    limit = 50; // 50으로 강제 고정
+
     List<Article> articles = articleRepository.searchArticles(keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit);
     List<ArticleDto> content = new ArrayList<>();
     Optional<User> user = userRepository.findById(requestUserId); // npe 날 수 있으니 예외 처리, 충돌을 우려하며 나중에 유저 쪽 코드랑 머지 되었을 때 예외 처리 추가
@@ -102,8 +104,10 @@ public class ArticleService {
       content.add(dto);
     }
 
+    CursorPageResponseArticleDto responseArticleDto = new CursorPageResponseArticleDto(content, nextCursor, nextAfter, size, totalElements, hasNex);
+
     log.info("뉴스 기사 검색 완료");
-    return new CursorPageResponseArticleDto(content, nextCursor, nextAfter, size, totalElements, hasNex);
+    return responseArticleDto;
   }
 
   public ArticleViewDto getArticleViewDto(UUID articleId, UUID requestUserId) {

--- a/src/test/java/com/codeit/monew/article/ArticleServiceTest.java
+++ b/src/test/java/com/codeit/monew/article/ArticleServiceTest.java
@@ -3,6 +3,9 @@ package com.codeit.monew.article;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -169,7 +172,17 @@ class ArticleServiceTest {
 
     List<Article> fetched = List.of(article1, article2, article3);
 
-    when(articleRepository.searchArticles(keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit
+    when(articleRepository.searchArticles(
+        eq(keyword),
+        eq(interestId),
+        eq(sourceIn),
+        eq(publishDateFrom),
+        eq(publishDateTo),
+        eq(orderBy),
+        eq(direction),
+        isNull(),                     // cursor
+        isNull(),                     // after
+        anyInt()
     )).thenReturn(fetched);
 
     // ★ 여기서 만든 requestUserId를 아래 서비스 호출에도 "그대로" 사용해야 함
@@ -200,7 +213,7 @@ class ArticleServiceTest {
     );
 
     // then
-    assertThat(res.content()).hasSize(2);      // limit 만큼만
+    assertThat(res.content()).hasSize(3);      // limit 만큼만
   }
 
   @Test


### PR DESCRIPTION
## 📌 작업 내용
- 뉴스기사 목록 조회 오류 수정

## 🔗 관련 이슈
- Closes #87 

## 🐛 에러 상황 및 원인 (선택)
- 검색 조건을 설정하고 검색하면 조회 결과의 갯수가 적게 조회 되는 오류 수정
- 각 페이지마다 중복된 기사가 조회되는 오류 수정

