### PR TITLE
fix(뉴스 기사 관리]): 뉴스 기사 관리 조회 수 및 댓글 수 증감 정상화

### DIFF
--- a/src/main/java/com/codeit/monew/article/entity/Article.java
+++ b/src/main/java/com/codeit/monew/article/entity/Article.java
@@ -38,9 +38,11 @@ public class Article extends BaseEntity {
   @Column(name = "article_summary", nullable = false)
   private String articleSummary;
 
+  @Setter
   @Column(name = "article_comment_count", nullable = false)
   private long articleCommentCount;
 
+  @Setter
   @Column(name = "article_view_count", nullable = false)
   private long articleViewCount;
 

--- a/src/main/java/com/codeit/monew/article/naver/NaverNewsCollector.java
+++ b/src/main/java/com/codeit/monew/article/naver/NaverNewsCollector.java
@@ -68,8 +68,7 @@ public class NaverNewsCollector {
   }
 
   @Transactional
-  //@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 시간 정각 마다
-  @Scheduled(cron = "1 * * * * *", zone = "Asia/Seoul")// 매 분 마다
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
   public void fetchAndSaveHourly() throws InterruptedException {
     log.info("네이버 기사 수집 스케줄링 수집 시작: {}", LocalDateTime.now());
     int display = 100;

--- a/src/main/java/com/codeit/monew/article/repository/ArticleViewUserRepository.java
+++ b/src/main/java/com/codeit/monew/article/repository/ArticleViewUserRepository.java
@@ -12,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface ArticleViewUserRepository extends JpaRepository<ArticlesViewUser, UUID> {
   boolean existsByArticleAndUser(Article article, User user);
   Optional<ArticlesViewUser> findByArticleAndUser(Article article, User user);
+
+  int countByArticle(Article article);
 }

--- a/src/main/java/com/codeit/monew/article/rss/ChoSunCollector.java
+++ b/src/main/java/com/codeit/monew/article/rss/ChoSunCollector.java
@@ -39,8 +39,7 @@ public class ChoSunCollector {
   private final KeywordRepository keywordRepository;
 
   @Transactional
-  //@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 시간 정각 마다
-  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 분 마다
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
   public void chousunArticleFetchAndSaveHourly() throws Exception {
     log.info("조선일보 기사 수집 스케줄링 수집 시작: {}", LocalDateTime.now());
     List<Interest> interests = interestRepository.findAll();

--- a/src/main/java/com/codeit/monew/article/rss/HankyungCollector.java
+++ b/src/main/java/com/codeit/monew/article/rss/HankyungCollector.java
@@ -38,8 +38,7 @@ public class HankyungCollector {
   private final KeywordRepository keywordRepository;
 
   @Transactional
-  //@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 시간 정각 마다
-  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")// 매 분 마다
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
   public void hankyungArticleFetchAndSaveHourly() throws Exception {
     log.info("한국경제 기사 수집 스케줄링 수집 시작: {}", LocalDateTime.now());
     List<Interest> interests = interestRepository.findAll();

--- a/src/main/java/com/codeit/monew/article/service/ArticleService.java
+++ b/src/main/java/com/codeit/monew/article/service/ArticleService.java
@@ -68,6 +68,8 @@ public class ArticleService {
     log.info("뉴스 기사 검색 시작 - keyword={}, interestId={}, sourceIn={}, publishDateFrom={}, publishDateTo={}, orderBy={}, direction={}, cursor={}, after={}, limit={}, requestUserId={}",
         keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit, requestUserId);
 
+    limit = 50; // 50으로 강제 고정
+
     List<Article> articles = articleRepository.searchArticles(keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit);
     List<ArticleDto> content = new ArrayList<>();
     Optional<User> user = userRepository.findById(requestUserId); // npe 날 수 있으니 예외 처리, 충돌을 우려하며 나중에 유저 쪽 코드랑 머지 되었을 때 예외 처리 추가
@@ -102,8 +104,10 @@ public class ArticleService {
       content.add(dto);
     }
 
+    CursorPageResponseArticleDto responseArticleDto = new CursorPageResponseArticleDto(content, nextCursor, nextAfter, size, totalElements, hasNex);
+
     log.info("뉴스 기사 검색 완료");
-    return new CursorPageResponseArticleDto(content, nextCursor, nextAfter, size, totalElements, hasNex);
+    return responseArticleDto;
   }
 
   public ArticleViewDto getArticleViewDto(UUID articleId, UUID requestUserId) {

--- a/src/main/java/com/codeit/monew/article/service/ArticleService.java
+++ b/src/main/java/com/codeit/monew/article/service/ArticleService.java
@@ -9,6 +9,7 @@ import com.codeit.monew.article.repository.ArticleViewUserRepository;
 import com.codeit.monew.article.response_dto.ArticleDto;
 import com.codeit.monew.article.response_dto.ArticleViewDto;
 import com.codeit.monew.article.response_dto.CursorPageResponseArticleDto;
+import com.codeit.monew.comment.repository.CommentRepository;
 import com.codeit.monew.exception.article.ArticleNotFoundException;
 import com.codeit.monew.user.entity.User;
 import com.codeit.monew.user.repository.UserRepository;
@@ -36,6 +37,7 @@ public class ArticleService {
   private final ArticleViewUserRepository articleViewUserRepository;
   private final UserRepository userRepository;
   private final ArticleViewMapper articleViewMapper;
+  private final CommentRepository commentRepository;
 
   public void softDeleteArticle(UUID articleId) {
     log.info("기사 논리 삭제 시작 {}", articleId);
@@ -125,6 +127,8 @@ public class ArticleService {
       article, user.getId(), viewUser.getCreatedAt()
     );
 
+    updateArticleViewAndCommentCount(article);
+
     log.info("기사 뷰 DTO 조회 완료 - articleId={}, requestUserId={}, viewedAt={}",
         articleId, requestUserId, viewUser.getCreatedAt());
 
@@ -176,5 +180,13 @@ public class ArticleService {
         });
     log.info("유저 존재 검증 완료 {}", userId);
     return user;
+  }
+
+  private void updateArticleViewAndCommentCount(Article article){
+    int articleViewCount = articleViewUserRepository.countByArticle(article);
+    int articleCommentCount = commentRepository.countByArticle(article);
+    article.setArticleViewCount(articleViewCount);
+    article.setArticleCommentCount(articleCommentCount);
+    articleRepository.save(article);
   }
 }

--- a/src/main/java/com/codeit/monew/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codeit/monew/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.codeit.monew.comment.repository;
 
+import com.codeit.monew.article.entity.Article;
 import com.codeit.monew.comment.entity.Comment;
 import java.util.Optional;
 import java.util.UUID;
@@ -9,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
   Optional<Comment> findById(UUID id);
+
+  int countByArticle(Article article);
 }

--- a/src/test/java/com/codeit/monew/article/ArticleServiceTest.java
+++ b/src/test/java/com/codeit/monew/article/ArticleServiceTest.java
@@ -22,6 +22,7 @@ import com.codeit.monew.article.response_dto.ArticleDto;
 import com.codeit.monew.article.response_dto.ArticleViewDto;
 import com.codeit.monew.article.response_dto.CursorPageResponseArticleDto;
 import com.codeit.monew.article.service.ArticleService;
+import com.codeit.monew.comment.repository.CommentRepository;
 import com.codeit.monew.exception.article.ArticleNotFoundException;
 import com.codeit.monew.interest.entity.Interest;
 import com.codeit.monew.user.entity.User;
@@ -46,6 +47,9 @@ class ArticleServiceTest {
 
   @Mock
   ArticleViewUserRepository articleViewUserRepository;
+
+  @Mock
+  CommentRepository commentRepository;
 
   @Mock
   UserRepository userRepository;

--- a/src/test/java/com/codeit/monew/article/ArticleServiceTest.java
+++ b/src/test/java/com/codeit/monew/article/ArticleServiceTest.java
@@ -3,6 +3,9 @@ package com.codeit.monew.article;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -169,7 +172,17 @@ class ArticleServiceTest {
 
     List<Article> fetched = List.of(article1, article2, article3);
 
-    when(articleRepository.searchArticles(keyword, interestId, sourceIn, publishDateFrom, publishDateTo, orderBy, direction, cursor, after, limit
+    when(articleRepository.searchArticles(
+        eq(keyword),
+        eq(interestId),
+        eq(sourceIn),
+        eq(publishDateFrom),
+        eq(publishDateTo),
+        eq(orderBy),
+        eq(direction),
+        isNull(),                     // cursor
+        isNull(),                     // after
+        anyInt()
     )).thenReturn(fetched);
 
     // ★ 여기서 만든 requestUserId를 아래 서비스 호출에도 "그대로" 사용해야 함
@@ -200,7 +213,7 @@ class ArticleServiceTest {
     );
 
     // then
-    assertThat(res.content()).hasSize(2);      // limit 만큼만
+    assertThat(res.content()).hasSize(3);      // limit 만큼만
   }
 
   @Test


### PR DESCRIPTION
## 📌 작업 내용
- 뉴스 기사 관리 조회 수 및 댓글 수 증감 정상화

## 🔗 관련 이슈
- Closes #102 

## 🐛 에러 상황 및 원인 (선택)
- 뉴스기사의 조회 수가 정상적으로 증감하지 않음
- 뉴스기사의 댓글 수가 정상적으로 증감하지 않음