### PR TITLE
fix(활동내역관리) : 삭제된 관심사 조회해오는 오류 수정

### DIFF
--- a/src/main/java/com/codeit/monew/activity_management/service/UserActivityService.java
+++ b/src/main/java/com/codeit/monew/activity_management/service/UserActivityService.java
@@ -73,7 +73,9 @@ public class UserActivityService {
         .from(subscription)
         .where(
             subscription.user.id.eq(userId)
-        ).fetch();
+                .and(subscription.interest.isDeleted.isFalse())
+        )
+        .fetch();
 
 
     for(Tuple interestTuple : interestTuples) {


### PR DESCRIPTION
## 📌 작업 내용
- [x] 소프트 삭제된 관심사 필터링 하기

## 🔗 관련 이슈
- Closes #110 

## 🐛 에러 상황 및 원인 (선택)
- 소프트 삭제된 관심사를 필터링 하지 않아 삭제된 관심사가 조회됨

## 🙋 리뷰 요청사항
- 리뷰어가 집중해서 봐주었으면 하는 부분을 작성해주세요.